### PR TITLE
Update Okta LDAP Agent to 05.04.06

### DIFF
--- a/okta-ldap-agent/Dockerfile
+++ b/okta-ldap-agent/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 MAINTAINER Aaron Picht <apicht@users.noreply.github.com>
 
 RUN yum update -y && \
-    yum install -y https://download.okta.com/static/ldap-agent/OktaLDAPAgent-05.04.02.x86_64.rpm && \
+    yum install -y https://download.okta.com/static/ldap-agent/OktaLDAPAgent-05.04.06.x86_64.rpm && \
     yum clean all
 
 RUN mv /opt/Okta/OktaLDAPAgent/conf/logback.xml /opt/Okta/OktaLDAPAgent/logback-default.xml


### PR DESCRIPTION
As per the title, this updates to the latest version of the Okta LDAP Agent.